### PR TITLE
Remove common Micro.blog elements from head and use new partial instead

### DIFF
--- a/layouts/partials/externals/styling.html
+++ b/layouts/partials/externals/styling.html
@@ -7,4 +7,3 @@
   <link rel="stylesheet" href="/assets/vendor/highlight/styles/solarized_dark.css">
 {{ end }}
 <link rel="stylesheet" href="{{ "assets/vendor/font-awesome/css/font-awesome.css" | relURL }}">
-<link rel="stylesheet" href="{{ "custom.css" | relURL }}">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,4 +3,5 @@
 	{{ partial "meta_tags/sharing.html" . }}
 
 	{{ partial "externals/styling.html" . }}
+	{{ partial "microblog_head.html" . }}
 </head>

--- a/layouts/partials/meta_tags/base.html
+++ b/layouts/partials/meta_tags/base.html
@@ -4,35 +4,3 @@
 <title>{{ if .Title }}{{ .Site.Title }} - {{ .Title }}{{ else }}{{ .Site.Title }}{{ end }}</title>
 
 <link rel="canonical" href="{{ .Permalink }}">
-
-<link rel="shortcut icon" href="https://micro.blog/{{ .Site.Author.username }}/favicon.png" type="image/x-icon" />
-
-    {{ if .RSSLink -}}
-      <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-      <link href="{{ "podcast.xml" | absURL }}" rel="alternate" type="application/rss+xml" title="Podcast" />
-      <link rel="alternate" type="application/json" title="{{ .Site.Title }}" href="{{ "feed.json" | absURL }}" />
-      <link rel="EditURI" type="application/rsd+xml" href="{{ "rsd.xml" | absURL }}" />
-    {{ end -}}
-
-	<link rel="me" href="https://micro.blog/{{ .Site.Author.username }}" />
-	{{ with .Site.Params.twitter_username }}
-		<link rel="me" href="https://twitter.com/{{ . }}" />
-	{{ end }}
-	{{ with .Site.Params.github_username }}
-		<link rel="me" href="https://github.com/{{ . }}" />
-	{{ end }}
-	{{ with .Site.Params.instagram_username }}
-		<link rel="me" href="https://instagram.com/{{ . }}" />
-	{{ end }}
-	<link rel="authorization_endpoint" href="https://micro.blog/indieauth/auth" />
-	<link rel="token_endpoint" href="https://micro.blog/indieauth/token" />
-	<link rel="micropub" href="https://micro.blog/micropub" />
-	<link rel="microsub" href="https://micro.blog/microsub" />
-	<link rel="webmention" href="https://micro.blog/webmention" />
-	<link rel="subscribe" href="https://micro.blog/users/follow" />
-  {{ range .Site.Params.plugins_css }}
-    <link rel="stylesheet" href="{{ . }}" />
-  {{ end }}
-  {{ range $filename := .Site.Params.plugins_html }}
-    {{ partial $filename $ }}
-  {{ end }}


### PR DESCRIPTION
Introducing the new partial to Typewriter. Tests pass on Hugo 0.117 and 0.91 and everything looks okay when building locally.